### PR TITLE
Fix typo in Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## When Something Happens
 
-If you see behavoir that makes you feel unsafe or unwelcome or otherwise uncomfortable, follow these steps:
+If you see behavior that makes you feel unsafe or unwelcome or otherwise uncomfortable, follow these steps:
 
 1. Let the person know that what they did is not appropriate and ask them to stop and/or edit their message(s) or commits.
 2. That person should immediately stop the behavior and correct the issue.


### PR DESCRIPTION
Just saw it when reading through and thought I'd make a pull request. Awesome project btw!

`behavoir` -> `behavior`