### PR TITLE
identifier and string tweaks

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -99,7 +99,7 @@ The following characters cannot be used anywhere in a bare
 
 * Any codepoint with hexadecimal value `0x20` or below.
 * Any codepoint with hexadecimal value higher than `0x10FFFF`.
-* Any of "\\<>{};[]=,"
+* Any of "\\<>{};[]=,\""
 
 ### Line Continuation
 
@@ -308,12 +308,14 @@ node-children := ('/-' ws*)? '{' nodes '}'
 node-space := ws* escline ws* | ws+
 node-terminator := single-line-comment | newline | ';' | eof
 
-identifier := (identifier-char - digit - [<>]) identifier-char*  | string
-identifier-char := unicode - digit - linespace - [\{}<>;[]=,]
+identifier := string | bare-identifier
+bare-identifier := (identifier-char - digit) identifier-char*
+identifier-char := unicode - linespace - [\{}<>;[]=,"]
 prop := identifier '=' value
-value := string | raw_string | number | boolean | 'null'
+value := string | number | boolean | 'null'
 
-string := '"' character* '"'
+string := raw-string | escaped-string
+escaped-string := '"' character* '"'
 character := '\' escape | [^\"]
 escape := ["\\/bfnrt] | 'u{' hex-digit{1, 6} '}'
 hex-digit := [0-9a-fA-F]


### PR DESCRIPTION
this does a few things with identifiers and strings:

- removes `"` from the set of identifier characters, to prevent ambiguity with string
- adds `bare-identifier` and `escaped-string` non-terminals (i think less mixing of terminal/non-terminal is easier to read?)
- moves string ahead of bare-identifier in identifier, for easier implementation with ordered-choice parsers
- moves raw-string into string, so you can have raw-string identifiers

(i'd be happy to break this up, if parts need more discussion)