### PR TITLE
add link to ruby implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ free to jump in and give us your 2 cents!
 
 * Rust: [kdl-rs](https://github.com/kdl-org/kdl-rs)
 * JavaScript: [kdljs](https://github.com/kdl-org/kdljs)
+* Ruby: [kdl-rb](https://github.com/jellymann/kdl-rb)
 
 ## Editor Support
 


### PR DESCRIPTION
Add a link to the Ruby implementation under the implementations section of the README

Resolves #53 