### PR TITLE
Mark strings in NuGet example as raw where needed.

### DIFF
--- a/examples/nuget.kdl
+++ b/examples/nuget.kdl
@@ -4,7 +4,7 @@ Project {
     IsCommandLinePackage true
   }
 
-  Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props"
+  Import Project=r"$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))\build\common.props"
   Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk"
   Import Project="ilmerge.props"
 
@@ -32,10 +32,10 @@ Project {
 
   Target Name="CreateCommandlineNupkg" {
     ItemGroup {
-      TfmSpecificPackageFile Include="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe" {
+      TfmSpecificPackageFile Include=r"$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe" {
         PackagePath "tools/"
       }
-      TfmSpecificPackageFile Include="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.pdb" {
+      TfmSpecificPackageFile Include=r"$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.pdb" {
         PackagePath "tools/"
       }
     }
@@ -83,14 +83,14 @@ Project {
     Reference Include="System.Xml"
     Reference Include="System.Xml.Linq"
     Reference Include="NuGet.Core" {
-      HintPath "$(SolutionPackagesFolder)nuget.core\2.14.0-rtm-832\lib\net40-Client\NuGet.Core.dll"
+      HintPath r"$(SolutionPackagesFolder)nuget.core\2.14.0-rtm-832\lib\net40-Client\NuGet.Core.dll"
       Aliases "CoreV2"
     }
   }
   ItemGroup {
     PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop"
-    ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.PackageManagement\NuGet.PackageManagement.csproj"
-    ProjectReference Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks\NuGet.Build.Tasks.csproj"
+    ProjectReference Include=r"$(NuGetCoreSrcDirectory)NuGet.PackageManagement\NuGet.PackageManagement.csproj"
+    ProjectReference Include=r"$(NuGetCoreSrcDirectory)NuGet.Build.Tasks\NuGet.Build.Tasks.csproj"
   }
 
   ItemGroup {
@@ -116,7 +116,7 @@ Project {
   }
 
   ItemGroup {
-    EmbeddedResource Include="$(NuGetCoreSrcDirectory)NuGet.Build.Tasks\NuGet.targets" {
+    EmbeddedResource Include=r"$(NuGetCoreSrcDirectory)NuGet.Build.Tasks\NuGet.targets" {
       Link "NuGet.targets"
       SubType "Designer"
     }
@@ -133,9 +133,9 @@ Project {
       ExpectedLocalizedArtifactCount 0 Condition="'$(ExpectedLocalizedArtifactCount)' == ''"
     }
     ItemGroup {
-      BuildArtifacts Include="$(OutputPath)\*.dll" Exclude="@(MergeExclude)"
+      BuildArtifacts Include=r"$(OutputPath)\*.dll" Exclude="@(MergeExclude)"
       // NuGet.exe needs all NuGet.Commands.resources.dll merged in
-      LocalizedArtifacts Include="$(ArtifactsDirectory)\NuGet.Commands\**\$(NETFXTargetFramework)\**\*.resources.dll"
+      LocalizedArtifacts Include=r"$(ArtifactsDirectory)\NuGet.Commands\**\$(NETFXTargetFramework)\**\*.resources.dll"
     }
     Error Text="Build dependencies are inconsistent with mergeinclude specified in ilmerge.props" \
           Condition="'@(BuildArtifacts-&gt;Count())' != '@(MergeInclude-&gt;Count())'"
@@ -143,7 +143,7 @@ Project {
           Condition="'@(LocalizedArtifacts-&gt;Count())' != '$(ExpectedLocalizedArtifactCount)'"
     PropertyGroup {
       PathToBuiltNuGetExe "$(OutputPath)NuGet.exe"
-      IlmergeCommand "$(ILMergeExePath) /lib:$(OutputPath) /out:$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe @(MergeAllowDup -> '/allowdup:%(Identity)', ' ') /log:$(OutputPath)IlMergeLog.txt"
+      IlmergeCommand r"$(ILMergeExePath) /lib:$(OutputPath) /out:$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe @(MergeAllowDup -> '/allowdup:%(Identity)', ' ') /log:$(OutputPath)IlMergeLog.txt"
       IlmergeCommand Condition="Exists($(MS_PFX_PATH))" "$(IlmergeCommand) /delaysign /keyfile:$(MS_PFX_PATH)"
       // LocalizedArtifacts need fullpath, since there will be duplicate file names
       IlmergeCommand "$(IlmergeCommand) $(PathToBuiltNuGetExe) @(BuildArtifacts->'%(filename)%(extension)', ' ') @(LocalizedArtifacts->'%(fullpath)', ' ')"
@@ -160,7 +160,7 @@ Project {
 
   Target Name="GetSigningInputs" Returns="@(DllsToSign)" {
     ItemGroup {
-      DllsToSign Include="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe" {
+      DllsToSign Include=r"$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe" {
         StrongName "MsSharedLib72"
         Authenticode "Microsoft400"
       }
@@ -169,8 +169,8 @@ Project {
 
   Target Name="GetSymbolsToIndex" Returns="@(SymbolsToIndex)" {
     ItemGroup {
-      SymbolsToIndex Include="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe"
-      SymbolsToIndex Include="$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.pdb"
+      SymbolsToIndex Include=r"$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.exe"
+      SymbolsToIndex Include=r"$(ArtifactsDirectory)$(VsixOutputDirName)\NuGet.pdb"
     }
   }
 


### PR DESCRIPTION
During testing of a Java implementation, I noticed that the NuGet example failed to parse. After digging into it I noticed that a number of strings in the file contained windows paths, delimited by `\`, causing illegal escape sequences. This marks all the needed strings as raw.