### PR TITLE
Possible typo in "Escapes" table

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -189,7 +189,7 @@ interpreted as described in the following table:
 | Quotation Mark (Double Quote) | `\"`   | `U+0022` |
 | Backspace                     | `\b`   | `U+0008` |
 | Form Feed                     | `\f`   | `U+000C` |
-| Unicode Escape                | `\u{(0-6 hex chars)}` | Code point described by hex characters, up to `10FFF` |
+| Unicode Escape                | `\u{(0-6 hex chars)}` | Code point described by hex characters, up to `10FFFF` |
 
 ### Raw String
 


### PR DESCRIPTION
The maximum unicode code point is `10FFFF` but in the escapes table it states code points can only go up to `10FFF`. I think this is an error, since most emojis are well above that number, and other languages allow escapes up to `10FFFF`