### PR TITLE
identifiers should never look like numbers

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -311,7 +311,7 @@ node-space := ws* escline ws* | ws+
 node-terminator := single-line-comment | newline | ';' | eof
 
 identifier := string | bare-identifier
-bare-identifier := (identifier-char - digit) identifier-char*
+bare-identifier := (identifier-char - digit - sign) identifier-char*
 identifier-char := unicode - linespace - [\{}<>;[]=,"]
 prop := identifier '=' value
 value := string | number | boolean | 'null'


### PR DESCRIPTION
This does mean that -foo is now illegal, when it wasn't before, but I think it's for the best?