### PR TITLE
Partially revert #99

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -80,7 +80,8 @@ foo 1 key="val" 3 {
 
 A bare Identifier is composed of any unicode codepoint other than [non-initial
 characters](#non-inidital-characters), followed by any number of unicode
-codepoints other than [non-identifier characters](#non-identifier-characters).
+codepoints other than [non-identifier characters](#non-identifier-characters),
+so long as this doesn't produce something confusable for a [Number](#number).
 Identifiers are terminated by [Whitespace](#whitespace) or
 [Newlines](#newline).
 
@@ -311,7 +312,7 @@ node-space := ws* escline ws* | ws+
 node-terminator := single-line-comment | newline | ';' | eof
 
 identifier := string | bare-identifier
-bare-identifier := (identifier-char - digit - sign) identifier-char*
+bare-identifier := (identifier-char - digit - sign) identifier-char* | sign ((identifier-char - digit) identifier-char*)?
 identifier-char := unicode - linespace - [\{}<>;[]=,"]
 prop := identifier '=' value
 value := string | number | boolean | 'null'


### PR DESCRIPTION
https://github.com/kdl-org/kdl/commit/6704988633f3252952bbf3c54f63b98248fb638d disallowed identifiers from ever starting with a sign character. This disallowed idents like `-`, or like the CSS `--foo` properties.

This change instead allows an ident to start with a sign character, so long as the *second* character isn't a digit.

I also tweaked the prose definition of identifier to talk about this restriction.