### PR TITLE
remove () from identifiers so we can use it for KQL

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -100,7 +100,7 @@ The following characters cannot be used anywhere in a bare
 
 * Any codepoint with hexadecimal value `0x20` or below.
 * Any codepoint with hexadecimal value higher than `0x10FFFF`.
-* Any of "\\<>{};[]=,\""
+* Any of "\\<>{};[]()=,\""
 
 ### Line Continuation
 
@@ -313,7 +313,7 @@ node-terminator := single-line-comment | newline | ';' | eof
 
 identifier := string | bare-identifier
 bare-identifier := (identifier-char - digit - sign) identifier-char* | sign ((identifier-char - digit) identifier-char*)?
-identifier-char := unicode - linespace - [\{}<>;[]=,"]
+identifier-char := unicode - linespace - [\(){}<>;[]=,"]
 prop := identifier '=' value
 value := string | number | boolean | 'null'
 


### PR DESCRIPTION
I want to use `()` for a potential query language, along with `[]`, so I'd like to ban them from identifiers. I think it's for the best!