### PR TITLE
Add some more reserved type annotations

### DIFF
--- a/SCHEMA-SPEC.md
+++ b/SCHEMA-SPEC.md
@@ -252,6 +252,12 @@ and property names when the `node-names` or `prop-names` options are activated.
     * `date-time`: ISO8601 date/time format.
     * `time`: "Time" section of ISO8601.
     * `date`: "Date" section of ISO8601.
+    * `duration`: ISO8601 duration format. 
+    * `decimal`: IEEE 754-2008 decimal string format.
+    * `currency`: ISO 4217 currency code.
+    * `country-2`: ISO 3166-1 alpha-2 country code.
+    * `country-3`: ISO 3166-1 alpha-3 country code.
+    * `country-subdivision`: ISO 3166-2 country subdivision code.
     * `email`: RFC5302 email address.
     * `idn-email`: RFC6531 internationalized email address.
     * `hostname`: RFC1132 internet hostname.

--- a/SCHEMA-SPEC.md
+++ b/SCHEMA-SPEC.md
@@ -248,7 +248,7 @@ and property names when the `node-names` or `prop-names` options are activated.
 * `pattern`: Regex pattern or patterns to test prop values against. Specific regex syntax may be implementation-dependent.
 * `min-length`: Minimum length, if a string.
 * `max-length`: Maximum length, if a string.
-* `format`: Intended data format, if the value is a string. Possible values are:
+* `format`: Intended data format, if the value is a string. Reserved values are:
     * `date-time`: ISO8601 date/time format.
     * `time`: "Time" section of ISO8601.
     * `date`: "Date" section of ISO8601.
@@ -280,6 +280,21 @@ and property names when the `node-names` or `prop-names` options are activated.
 * `>=`: Greater than or equal to.
 * `<`: Less than.
 * `<=`: Less than or equal to.
+* `format`: Intended data format for numeric values. Reserved values are:
+    * `i8`: 8-bit signed integer
+    * `i16`: 16-bit signed integer
+    * `i32`: 32-bit signed integer
+    * `i64`: 64-bit signed integer
+    * `u8`: 8-bit unsigned integer
+    * `u16`: 16-bit unsigned integer
+    * `u32`: 32-bit unsigned integer
+    * `u64`: 64-bit unsigned integer
+    * `isize`: Platform-dependent signed integer
+    * `usize`: Platform-dependent unsigned integer
+    * `f32`: IEEE 754 single (32-bit) precision floating point number
+    * `f64`: IEEE 754 double (64-bit) precision floating point number
+    * `decimal64`: IEEE 754-2008 64-bit decimal floating point number
+    * `decimal128`: IEEE 754-2008 128-bit decimal floating point number
 
 ### `definitions` node
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -236,16 +236,26 @@ Platform-dependent integer types, both signed and unsigned:
 * `isize`
 * `usize`
 
+#### Reserved Type Annotations for Numbers With Decimals:
+
 IEEE 754 floating point numbers, both single (32) and double (64) precision:
 
 * `f32`
 * `f64`
+
+IEEE754-2008 decimal floating point numbers
+
+* `decimal64`
+* `decimal128`
 
 #### Reserved Type Annotations for Strings:
 
 * `date-time`: ISO8601 date/time format.
 * `time`: "Time" section of ISO8601.
 * `date`: "Date" section of ISO8601.
+* `duration`: ISO8601 duration format. 
+* `decimal`: IEEE754-2008 decimal string format.
+* `money`: TBD
 * `email`: RFC5302 email address.
 * `idn-email`: RFC6531 internationalized email address.
 * `hostname`: RFC1132 internet hostname.

--- a/SPEC.md
+++ b/SPEC.md
@@ -243,7 +243,7 @@ IEEE 754 floating point numbers, both single (32) and double (64) precision:
 * `f32`
 * `f64`
 
-IEEE754-2008 decimal floating point numbers
+IEEE 754-2008 decimal floating point numbers
 
 * `decimal64`
 * `decimal128`
@@ -254,8 +254,11 @@ IEEE754-2008 decimal floating point numbers
 * `time`: "Time" section of ISO8601.
 * `date`: "Date" section of ISO8601.
 * `duration`: ISO8601 duration format. 
-* `decimal`: IEEE754-2008 decimal string format.
-* `money`: TBD
+* `decimal`: IEEE 754-2008 decimal string format.
+* `currency`: ISO 4217 currency code.
+* `country-2`: ISO 3166-1 alpha-2 country code.
+* `country-3`: ISO 3166-1 alpha-3 country code.
+* `country-subdivision`: ISO 3166-2 country subdivision code.
 * `email`: RFC5302 email address.
 * `idn-email`: RFC6531 internationalized email address.
 * `hostname`: RFC1132 internet hostname.

--- a/examples/kdl-schema.kdl
+++ b/examples/kdl-schema.kdl
@@ -224,13 +224,13 @@ document {
                                     type "number"
                                 }
                             }
-                            node "format" description="Intended data format, if the value is a string." {
+                            node "format" description="Intended data format." {
                                 max 1
                                 value {
                                     min 1
                                     type "string"
                                     // https://json-schema.org/understanding-json-schema/reference/string.html#format
-                                    enum "date-time" "date" "time" "email" "idn-email" "hostname" "idn-hostname" "ipv4" "ipv6" "uri" "uri-reference" "iri", "iri-reference" "uri-template" "regex" "uuid"
+                                    enum "date-time" "date" "time" "duration" "decimal" "currency" "country-2" "country-3" "country-subdivision" "email" "idn-email" "hostname" "idn-hostname" "ipv4" "ipv6" "uri" "uri-reference" "iri", "iri-reference" "uri-template" "regex" "uuid" "i8" "i16" "i32" "i64" "u8" "u16" "u32" "u64" "isize" "usize" "f32" "f64" "decimal64" "decimal128"
                                 }
                             }
                             node "%" description="Only used for numeric values. Constrains them to be multiples of the given number(s)" {


### PR DESCRIPTION
I think it would be useful to get these few more common data types into 
For the decimal floating types, I referenced [this protobuf discussion](https://github.com/protocolbuffers/protobuf/pull/7039#issuecomment-679083593) and [this](https://github.com/googleapis/googleapis/blob/master/google/type/decimal.proto)

I'm not sure what to call out for the currency format, I can't find a standard for that yet. There's a [protobuf money type](https://github.com/googleapis/googleapis/blob/master/google/type/money.proto) that's basically a ISO 4217 currency code plus a decimal number, but I don't really want to invent a suggested money format if there's a real one out there somewhere.
For this PR, can we just leave it TBD in order to reserve the type keyword?