### PR TITLE
Prevent markdown from parsing []() as link

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -107,7 +107,7 @@ The following characters cannot be used anywhere in a bare
 
 * Any codepoint with hexadecimal value `0x20` or below.
 * Any codepoint with hexadecimal value higher than `0x10FFFF`.
-* Any of "\\/<>{};[]()=,\""
+* Any of `\/<>{};()[]=,"`
 
 ### Line Continuation
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -107,7 +107,7 @@ The following characters cannot be used anywhere in a bare
 
 * Any codepoint with hexadecimal value `0x20` or below.
 * Any codepoint with hexadecimal value higher than `0x10FFFF`.
-* Any of `\/<>{};()[]=,"`
+* Any of `\/(){}<>;[]=,"`
 
 ### Line Continuation
 


### PR DESCRIPTION
Markdown was evaluating `[]()` as a link and not showing those characters under the "Non-identifier characters" section. Wrapping it in a code block fixes this and IMO makes the set of characters more obvious (plus, consistent with values above it).