### PR TITLE
Update line continuation wording

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -113,10 +113,9 @@ The following characters cannot be used anywhere in a bare
 
 Line continuations allow [Nodes](#node) to be spread across multiple lines.
 
-A line continuation is one or more [whitespace](#whitespace) characters,
-followed by a `\` character. This character can then be followed by more
-[whitespace](#whitespace) and must be terminated by a [Newline](#newline)
-(including the Newline that is part of single-line comments).
+A line continuation is a `\` character followed by zero or more whitespace
+characters and an optional single-line comment. It must be terminated by a
+[Newline](#newline) (including the Newline that is part of single-line comments).
 
 Following a line continuation, processing of a Node can continue as usual.
 


### PR DESCRIPTION
This commit updates the spec's wording around line continuations, which currently says that the `\` character must have one or more whitespace characters preceding it. That seems to conflict with the grammar definition (i.e., `node-space := ws* escline ws* | ws+`) and behavior of the kdl-rs library.