### PR TITLE
Do not escape solidus (forwardslash) in test

### DIFF
--- a/tests/test_cases/expected_kdl/all_escapes.kdl
+++ b/tests/test_cases/expected_kdl/all_escapes.kdl
@@ -1,1 +1,1 @@
-node "\"\\\/\b\f\n\r\t"
+node "\"\\/\b\f\n\r\t"


### PR DESCRIPTION
The solidus (forwardslash) character does not _need_ to be escaped in strings, but in an effort not to break the spec now that we're in 1.0, we could allow the character to be escaped during parsing, but not escape it when stringifying. This would also require no changes to the grammar.