### PR TITLE
Verify that a slash-dashed prop doesn't shadow a previous prop of the same name

### DIFF
--- a/tests/test_cases/expected_kdl/slashdash_repeated_prop.kdl
+++ b/tests/test_cases/expected_kdl/slashdash_repeated_prop.kdl
@@ -1,0 +1,1 @@
+node arg="correct"

--- a/tests/test_cases/input/slashdash_repeated_prop.kdl
+++ b/tests/test_cases/input/slashdash_repeated_prop.kdl
@@ -1,0 +1,1 @@
+node arg="correct" /- arg="wrong"


### PR DESCRIPTION
I accidentally ran into this while fiddling with my impl and realized I wasn't failing any tests as a result.