### PR TITLE
Allow "empty" single line comments in the spec

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -493,7 +493,7 @@ bom := '\u{FEFF}'
 
 unicode-space := See Table (All White_Space unicode characters which are not `newline`)
 
-single-line-comment := '//' ^newline+ (newline | eof)
+single-line-comment := '//' ^newline* (newline | eof)
 multi-line-comment := '/*' commented-block
 commented-block := '*/' | (multi-line-comment | '*' | '/' | [^*/]+) commented-block
 ```


### PR DESCRIPTION
As I read the grammar in the spec, `"//"` wouldn't parse as a single-line-comment as it requires as least one non-newline character after the slashes.