### PR TITLE
Define `digit` in formal grammar

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -446,9 +446,10 @@ raw-string-quotes := '"' .* '"'
 
 number := decimal | hex | octal | binary
 
-decimal := integer ('.' [0-9] [0-9_]*)? exponent?
-exponent := ('e' | 'E') integer
-integer := sign? [0-9] [0-9_]*
+decimal := sign? integer ('.' integer)? exponent?
+exponent := ('e' | 'E') sign? integer
+integer := digit (digit | '_')*
+digit := [0-9]
 sign := '+' | '-'
 
 hex := sign? '0x' hex-digit (hex-digit | '_')*


### PR DESCRIPTION
`digit` is used as a subtraction in bare-identifier, but never defined.

--- 

An alternate change:

```
decimal := integer ('.' digit digit_*)? exponent?
exponent := ('e' | 'E') integer
integer := sign? digit digit_*
digit := [0-9]
digit_ := [0-9_]
sign := '+' | '-'
```

(NOTE: this has now flip-flopped to opposite what it was when @tabatkins made their comment.)

I think I slightly prefer the PR'd version, but it changes the implied grammar tree structure more significantly. This change "just" gives names to the `[0-9]` and `[0-9_]` productions.