### PR TITLE
Add link to additional python implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ free to jump in and give us your 2 cents!
 * Dart: [kdl-dart](https://github.com/danini-the-panini/kdl-dart)
 * Java: [kdl4j](https://github.com/hkolbeck/kdl4j)
 * PHP: [kdl-php](https://github.com/kdl-org/kdl-php)
-* Python: [kdl-py](https://github.com/tabatkins/kdlpy)
+* Python: [kdl-py](https://github.com/tabatkins/kdlpy), [cuddle](https://github.com/djmattyg007/python-cuddle)
 * Elixir: [kuddle](https://github.com/IceDragon200/kuddle)
 * XSLT: [xml2kdl](https://github.com/Devasta/XML2KDL)
 


### PR DESCRIPTION
I created this implementation by forking the now-defunct original kdl-py implementation. It differs from the existing implementation in a few important ways:

- It provides a more python-native interface akin to the existing JSON and YAML packages
- It provides powerful support for custom types, while ensuring support for built-in types is first-class
- It deliberately doesn't provide as much control over the encoding process as kdl-py does