### PR TITLE
Minimal fix to #200, banning string-like idents

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -430,7 +430,7 @@ identifier := string | bare-identifier
 bare-identifier := (unambiguous-ident | numberish-ident | stringish-ident) - keyword
 unambiguous-ident := (identifier-char - digit - sign - "r") identifier-char*
 numberish-ident := sign ((identifier-char - digit) identifier-char*)?
-stringish-ident := "r" ((identifier-char - [#"]) identifier-char*)?
+stringish-ident := "r" ((identifier-char - "#") identifier-char*)?
 identifier-char := unicode - linespace - [\/(){}<>;[]=,"]
 keyword := boolean | 'null'
 prop := identifier '=' value

--- a/SPEC.md
+++ b/SPEC.md
@@ -427,7 +427,10 @@ node-space := ws* escline ws* | ws+
 node-terminator := single-line-comment | newline | ';' | eof
 
 identifier := string | bare-identifier
-bare-identifier := ((identifier-char - digit - sign) identifier-char* | sign ((identifier-char - digit) identifier-char*)?) - keyword
+bare-identifier := (unambiguous-ident | numberish-ident | stringish-ident) - keyword
+unambiguous-ident := (identifier-char - digit - sign - "r") identifier-char*
+numberish-ident := sign ((identifier-char - digit) identifier-char*)?
+stringish-ident := "r" ((identifier-char - [#"]) identifier-char*)?
 identifier-char := unicode - linespace - [\/(){}<>;[]=,"]
 keyword := boolean | 'null'
 prop := identifier '=' value


### PR DESCRIPTION
Rather than banning `#` in idents altogether, as #204 does, this takes the same approach as our number-like handling, and just bans idents from looking like a raw string *in their first two characters*: just as an ident can't start with `digit` or `sign digit`, it now can't start with `r#` or `r"` either.  (That last isn't an ident, but it prevents a naive parser not using first-wins collision resolution from reading it as an ident `r` followed by junk.)

It also refactors the bare-ident production a bit to make the structure clearer, as it was already getting a bit messy just trying to ban number-likes.