### PR TITLE
Add link to Haskell implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ free to jump in and give us your 2 cents!
 * Python: [kdl-py](https://github.com/tabatkins/kdlpy), [cuddle](https://github.com/djmattyg007/python-cuddle)
 * Elixir: [kuddle](https://github.com/IceDragon200/kuddle)
 * XSLT: [xml2kdl](https://github.com/Devasta/XML2KDL)
+* Haskell: [Hustle](https://github.com/fuzzypixelz/Hustle)
 
 ## Compatibility Test Suite
 


### PR DESCRIPTION
I started working on this following A Hacker News post, so about a month ago. I believe Hustle still needs more testing to
be actually useful, so I'm hoping people can point to issues if they start playing around with it. This is not the Go nor the C
implementation you guys have been waiting for, however.