### PR TITLE
Add link to Go implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ free to jump in and give us your 2 cents!
 * OCaml: [ocaml-kdl](https://github.com/Bannerets/ocaml-kdl)
 * Nim: [kdl-nim](https://github.com/Patitotective/kdl-nim)
 * Common Lisp: [kdlcl](https://github.com/chee/kdlcl)
+* Go: [gokdl](https://github.com/lunjon/gokdl)
 
 ## Compatibility Test Suite
 


### PR DESCRIPTION
I've attempted to write a parser implementation in Go. It is not entirely complete, but almost.

Would it be okay to add as implementation?

Thanks in advance!