### PR TITLE
Add kdl-go to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ free to jump in and give us your 2 cents!
 * OCaml: [ocaml-kdl](https://github.com/Bannerets/ocaml-kdl)
 * Nim: [kdl-nim](https://github.com/Patitotective/kdl-nim)
 * Common Lisp: [kdlcl](https://github.com/chee/kdlcl)
-* Go: [gokdl](https://github.com/lunjon/gokdl)
+* Go: [gokdl](https://github.com/lunjon/gokdl), [kdl-go](https://github.com/sblinch/kdl-go)
 
 ## Compatibility Test Suite
 


### PR DESCRIPTION
I've just released a complete KDL library for Go -- hoping to have it added here. It passes all test cases and includes marshal/unmarshal support similar to equivalent Go JSON/YAML/TOML libs.
