### PR TITLE
docs: add link to neovim integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ entirety, but in the future, may be required to in order to be included here.
 * [VS Code](https://marketplace.visualstudio.com/items?itemName=kdl-org.kdl&ssr=false#review-details)
 * [Sublime Text](https://packagecontrol.io/packages/KDL)
 * [vim](https://github.com/imsnif/kdl.vim)
+* [neovim](https://github.com/nvim-treesitter/nvim-treesitter)
 * [Intellij IDEA](https://plugins.jetbrains.com/plugin/20136-kdl-document-language)
 
 ## Overview


### PR DESCRIPTION
I included some additional information in the commit message, which can be seen below. I had a difficult time setting neovim up with kdl so I figured it might be better to have it somewhere.

> The neovim integration uses https://github.com/nvim-treesitter/nvim-treesitter which currently requires "Neovim 0.9.2 or later (nightly recommended)". See the up to date requirements in the project's readme: https://github.com/nvim-treesitter/nvim-treesitter?tab=readme-ov-file#requirements
> 
> A rough and unmaintained configuration example can be found here:  https://github.com/kdl-org/kdl/issues/258#issuecomment-1890912634
> 
> (It might serve as a good starting point)

Related issue: #258 although that is for **vim**, not for neovim. Only realized this now, and it's a bit confusing 😅 