### PR TITLE
kql: only allow top() at start of selector

### DIFF
--- a/QUERY-SPEC.md
+++ b/QUERY-SPEC.md
@@ -30,6 +30,11 @@ properties, node names, etc). With the exception of `top()` and `()`, they are a
 used inside a `[]` selector. Some matchers are unary, but most of them involve
 binary operators.
 
+The `top()` matcher can only be used as the first matcher of a selector. This means
+that it cannot be the right operand of the `>`, `>>`, `+`, or `++` operators. As `||`
+combines selectors, the `top()` can appear just after it. For instance,
+ `a > b || top() > b` is valid, but `a > top()` is not.
+
 * `top()`: Returns all toplevel children of the current document.
 * `top() > []`: Equivalent to `top()` on its own.
 * `(foo)`: Selects any element whose type annotation is `foo`.

--- a/QUERY-SPEC.md
+++ b/QUERY-SPEC.md
@@ -110,8 +110,9 @@ what they expand to.
 
 ```
 query-str := $bom? query
-query := selector q-ws* "||" q-ws* query | selector
-selector := filter q-ws* selector-operator q-ws* selector | filter
+query := selector-start q-ws* "||" q-ws* query | selector-start
+selector-start := filter q-ws* selector-operator q-ws* selector | filter
+selector := matchers q-ws* selector-operator q-ws* selector | matchers
 selector-operator := ">>" | ">" | "++" | "+"
 filter := "top(" q-ws* ")" | matchers
 matchers := type-matcher $string? accessor-matcher* | $string accessor-matcher* | accessor-matcher+

--- a/QUERY-SPEC.md
+++ b/QUERY-SPEC.md
@@ -115,9 +115,9 @@ what they expand to.
 
 ```
 query-str := $bom? query
-query := selector-start q-ws* "||" q-ws* query | selector-start
-selector-start := filter q-ws* selector-operator q-ws* selector | filter
-selector := matchers q-ws* selector-operator q-ws* selector | matchers
+query := selector q-ws* "||" q-ws* query | selector
+selector := filter q-ws* selector-operator q-ws* selector-subsequent | filter
+selector-subsequent := matchers q-ws* selector-operator q-ws* selector-subsequent | matchers
 selector-operator := ">>" | ">" | "++" | "+"
 filter := "top(" q-ws* ")" | matchers
 matchers := type-matcher $string? accessor-matcher* | $string accessor-matcher* | accessor-matcher+


### PR DESCRIPTION
Following discussion #387, I propose a change to the KQL grammar. With this change, `top()` will only be allowed at the start of a KQL selector.