### PR TITLE
[v2] Clarify how whitespace escapes work in multi-line strings

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -386,8 +386,10 @@ such) are retained. For example, these strings are all semantically identical:
 ```kdl
 "Hello\       \nWorld"
 
-    "Hello\n\
-    World"
+    "
+    Hello\n\
+        World
+    "
 
 "Hello\nWorld"
 
@@ -437,10 +439,9 @@ The string contains the literal characters `hello\n\r\asd"#world`
 
 ### Multi-line Strings
 
-When a Quoted or Raw String spans multiple lines with literal, non-escaped
-Newlines, it follows a special multi-line syntax that automatically "dedents"
-the string, allowing its value to be indented to a visually matching level if
-desired.
+When a Quoted or Raw String spans multiple lines with literal Newlines, it
+follows a special multi-line syntax that automatically "dedents" the string,
+allowing its value to be indented to a visually matching level if desired.
 
 A Multi-line string _MUST_ start with a [Newline](#newline) immediately
 following its opening `"`. Its final line _MUST_ contain only whitespace,

--- a/tests/test_cases/input/escaped_whitespace.kdl
+++ b/tests/test_cases/input/escaped_whitespace.kdl
@@ -6,10 +6,14 @@ node \
 		World
 	" \
 	"Hello\n\      \tWorld" \
-	"Hello\n\
-    \tWorld" \
-	"Hello\n\t\
-        World"
+	"
+ 	Hello\n\
+ 	\tWorld
+ 	" \
+	"
+  	 Hello\n\t\
+  	       World
+  	 "
 
 // Note that this file deliberately mixes space and newline indentation for
 // test purposes

--- a/tests/test_cases/input/string_escaped_literal_whitespace.kdl
+++ b/tests/test_cases/input/string_escaped_literal_whitespace.kdl
@@ -1,2 +1,4 @@
-node "Hello \
-World \          Stuff"
+node "
+Hello \
+World \          Stuff
+"


### PR DESCRIPTION
One example in the spec and two test cases appeared to contradict the language of the spec, see comment https://github.com/kdl-org/kdl/pull/286#issuecomment-2131307578