### PR TITLE
Add an optional version marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,8 +73,7 @@
   intuitive. They can now be used in exactly three different places: before nodes,
   before entire entries, or before entire child blocks.
 * Furthermore, The ordering of slashdashed elements has been restricted such
-  that a slashdashed child block cannot go before an entry (including slashdashed
-  entries).
+* Optional version marker `/- kdl-version 2` (or `1`) as the first line in a document, optionally preceded by the BOM.
 
 ### KQL
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -926,7 +926,7 @@ line-space := node-space | newline | single-line-comment
 node-space := ws* escline ws* | ws+
 
 // Version marker
-version := '/-' unicode-space* 'kdl-version' unicode-space* ('1' | '2')
+version := '/-' unicode-space* 'kdl-version' unicode-space* ('1' | '2') unicode-space* newline
 ```
 
 ### Grammar language

--- a/SPEC.md
+++ b/SPEC.md
@@ -926,7 +926,7 @@ line-space := node-space | newline | single-line-comment
 node-space := ws* escline ws* | ws+
 
 // Version marker
-version := '/-' unicode-space* 'kdl-version' unicode-space* ('1' | '2') unicode-space* newline
+version := '/-' unicode-space* 'kdl-version' unicode-space+ ('1' | '2') unicode-space* newline
 ```
 
 ### Grammar language

--- a/SPEC.md
+++ b/SPEC.md
@@ -828,6 +828,10 @@ They may be represented in Strings (but not Raw Strings) using [Unicode Escapes]
 * `U+FEFF`, aka Zero-width Non-breaking Space (ZWNBSP)/Byte Order Mark (BOM),
   except as the first code point in a document.
 
+### Version marker
+
+A version marker `/- kdl-version 2` (or `1`) _MAY_  be added to the beginning of a KDL document, optionally preceded by the BOM, and parsers _MAY_ use that as a hint as to which version to parse the document as.
+
 ## Full Grammar
 
 This is the full official grammar for KDL and should be considered
@@ -835,7 +839,7 @@ authoritative if something seems to disagree with the text above. The [grammar
 language syntax](#grammar-language) is defined below.
 
 ```
-document := bom? nodes
+document := bom? version? nodes
 
 // Nodes
 nodes := (line-space* node)* line-space*
@@ -920,6 +924,9 @@ newline := See Table (All Newline White_Space)
 line-space := node-space | newline | single-line-comment
 // Whitespace within nodes, where newline-ish things must be esclined.
 node-space := ws* escline ws* | ws+
+
+// Version marker
+version := '/-' unicode-space*? 'kdl-version' unicode-space*? ('1' | '2') line-space*
 ```
 
 ### Grammar language

--- a/SPEC.md
+++ b/SPEC.md
@@ -926,7 +926,7 @@ line-space := node-space | newline | single-line-comment
 node-space := ws* escline ws* | ws+
 
 // Version marker
-version := '/-' unicode-space*? 'kdl-version' unicode-space*? ('1' | '2') line-space*
+version := '/-' unicode-space* 'kdl-version' unicode-space* ('1' | '2')
 ```
 
 ### Grammar language


### PR DESCRIPTION
As discussed in the linked issue, adding an **OPTIONAL HINT** for the specific KDL version

`/- kdl-version 2` (or `1`) with the only difference from a slash-dashed node is that only unicode space is allowed, so no newlines and (multiline) comments

Didn't update the v1 spec as it's described as an unchanging legacy document

Also didn't mention in the readme as the marker isn't considered important enough :)

Also didn't add any tests as the status is a hint

Close https://github.com/kdl-org/kdl/issues/443