### PR TITLE
fix: move vertical tab to the line-breaking whitespace table

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -742,7 +742,6 @@ space](https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt):
 | Name                 | Code Pt |
 |----------------------|---------|
 | Character Tabulation | `U+0009`  |
-| Line Tabulation      | `U+000B`  |
 | Space                | `U+0020`  |
 | No-Break Space       | `U+00A0`  |
 | Ogham Space Mark     | `U+1680`  |
@@ -805,6 +804,7 @@ lines](https://www.unicode.org/versions/Unicode13.0.0/ch05.pdf):
 | CR      | Carriage Return | `U+000D`  |
 | LF      | Line Feed       | `U+000A`  |
 | NEL     | Next Line       | `U+0085`  |
+| VT      | Vertical tab    | `U+000B`  |
 | FF      | Form Feed       | `U+000C`  |
 | LS      | Line Separator  | `U+2028`  |
 | PS      | Paragraph Separator | `U+2029` |


### PR DESCRIPTION
Currently linebreaking vertical tab is in the non-line-breaking whitespace table

(this mistake was prompted by https://github.com/kdl-org/kdl/issues/331)

Not sure what the impact of this is re. parsers and tests and other docs and whether this should be changeloged or just a documentation issue.


https://www.unicode.org/versions/Unicode13.0.0/ch05.pdf that the spec references agrees:

(bad copy&paste, blame PDF standard!)
5.8 Newline Guidelines
....
Table 5-1. Hex Values for Acronyms
Acronym Name Unicode ASCII EBCDIC
Default z/OS
CR carriage return 000D 0D 0D 0D
LF line feed 000A 0A 25 15
CRLF carriage return and
line feed <000D 000A> <0D 0A> <0D 25> <0D 15>
NEL next line 0085 85 15 25
VT vertical tab 000B 0B 0B 0B
FF form feed 000C 0C 0C 0C
LS line separator 2028 n/a n/a n/a
PS paragraph separator 2029 n/a n/a n/a
