### PR TITLE
doc: change Unicode link to a friendly html version

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -800,7 +800,7 @@ comments (other than other slashdashes), before the element that it comments out
 ### Newline
 
 The following character sequences [should be treated as new
-lines](https://www.unicode.org/versions/Unicode13.0.0/ch05.pdf):
+lines](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-5/#G41643):
 
 | Acronym | Name            | Code Pt |
 |---------|-----------------|---------|

--- a/SPEC_v1.md
+++ b/SPEC_v1.md
@@ -468,19 +468,19 @@ can be nested.
 ### Newline
 
 The following characters [should be treated as new
-lines](https://www.unicode.org/versions/Unicode13.0.0/ch05.pdf):
+lines](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-5/#G41643):
 
 | Acronym | Name            | Code Pt |
 |---------|-----------------|---------|
+| CRLF    | Carriage Return and Line Feed | `U+000D` + `U+000A` |
 | CR      | Carriage Return | `U+000D`  |
 | LF      | Line Feed       | `U+000A`  |
-| CRLF    | Carriage Return and Line Feed | `U+000D` + `U+000A` |
 | NEL     | Next Line       | `U+0085`  |
 | FF      | Form Feed       | `U+000C`  |
 | LS      | Line Separator  | `U+2028`  |
 | PS      | Paragraph Separator | `U+2029` |
 
-Note that for the purpose of new lines, CRLF is considered _a single newline_.
+Note that for the purpose of new lines, CRLF is considered _a single newline_. `VT` `Vertical tab` `U+000B` was mistakenly excluded, but the v1 spec if frozen, so it's left unchanged.
 
 ## Full Grammar
 


### PR DESCRIPTION
That opens the table straight away instead of showing the very informative copyright notices

(Unicode version bumped, but the table is the same)

Spec v1 is missing the vertical tab even if some formatters might support it, but that's intentionally frozen, so only did a formatting change there and noted that it's missing intentionally now