### PR TITLE
test: add a fail-test for escaped non Unicode Scalar Values

### DIFF
--- a/tests/test_cases/input/unicode_escaped_fail.kdl
+++ b/tests/test_cases/input/unicode_escaped_fail.kdl
@@ -1,0 +1,1 @@
+no "Surrogates high\u{D800}\u{D911}\u{DABB}\u{DBFF} low\u{DC00}\u{DEAD}\u{DFFF}"


### PR DESCRIPTION
Closes https://github.com/kdl-org/kdl/issues/451