### PR TITLE
Exclude hex above max Unicode Scalar Value

### DIFF
--- a/draft-marchan-kdl2.md
+++ b/draft-marchan-kdl2.md
@@ -983,8 +983,13 @@ string-character :=
     [^\\"] - disallowed-literal-code-points
 ws-escape := '\\' (unicode-space | newline)+
 hex-digit := [0-9a-fA-F]
-hex-unicode := [\u{0}-\u{10FFFF}] - surrogate  // Unicode Scalar Value₁₆, leading 0s allowed as long as length ≤ 6
-surrogate := [\u{D800}-\u{DFFF}]
+hex-unicode := hex-digit{1, 6} - surrogate - above-max-scalar  // Unicode Scalar Value in hex₁₆, leading 0s allowed within length ≤ 6
+surrogate := [0]{0,2}[dD][8-9a-fA-F]hex-digit{2}
+//  U+D800-DFFF:       D  8         00
+//                     D  F         FF
+above-max-scalar = [2-9a-fA-F]hex-digit{5} | [1][1-9a-fA-F]hex-digit{4}
+// >U+10FFFF:      >1         _____           1 >0         ____
+
 
 raw-string := '#' raw-string-quotes '#' | '#' raw-string '#'
 raw-string-quotes :=

--- a/draft-marchan-kdl2.md
+++ b/draft-marchan-kdl2.md
@@ -984,11 +984,11 @@ string-character :=
 ws-escape := '\\' (unicode-space | newline)+
 hex-digit := [0-9a-fA-F]
 hex-unicode := hex-digit{1, 6} - surrogate - above-max-scalar  // Unicode Scalar Value in hex₁₆, leading 0s allowed within length ≤ 6
-surrogate := [0]{0,2}[dD][8-9a-fA-F]hex-digit{2}
-//  U+D800-DFFF:       D  8         00
-//                     D  F         FF
-above-max-scalar = [2-9a-fA-F]hex-digit{5} | [1][1-9a-fA-F]hex-digit{4}
-// >U+10FFFF:      >1         _____           1 >0         ____
+surrogate := [0]{0, 2} [dD] [8-9a-fA-F] hex-digit{2}
+//  U+D800-DFFF:         D   8          00
+//                       D   F          FF
+above-max-scalar = [2-9a-fA-F] hex-digit{5} | [1] [1-9a-fA-F] hex-digit{4}
+// >U+10FFFF:      >1          _____           1  >0          ____
 
 
 raw-string := '#' raw-string-quotes '#' | '#' raw-string '#'

--- a/draft-marchan-kdl2.md
+++ b/draft-marchan-kdl2.md
@@ -983,10 +983,8 @@ string-character :=
     [^\\"] - disallowed-literal-code-points
 ws-escape := '\\' (unicode-space | newline)+
 hex-digit := [0-9a-fA-F]
-hex-unicode := hex-digit{1, 6} - surrogates
-surrogates := [dD][8-9a-fA-F]hex-digit{2}
-// U+D800-DFFF: D  8         00
-//              D  F         FF
+hex-unicode := [\u{0}-\u{10FFFF}] - surrogate  // Unicode Scalar Value₁₆
+surrogate := [\u{D800}-\u{DFFF}]
 
 raw-string := '#' raw-string-quotes '#' | '#' raw-string '#'
 raw-string-quotes :=

--- a/draft-marchan-kdl2.md
+++ b/draft-marchan-kdl2.md
@@ -983,7 +983,7 @@ string-character :=
     [^\\"] - disallowed-literal-code-points
 ws-escape := '\\' (unicode-space | newline)+
 hex-digit := [0-9a-fA-F]
-hex-unicode := [\u{0}-\u{10FFFF}] - surrogate  // Unicode Scalar Value₁₆
+hex-unicode := [\u{0}-\u{10FFFF}] - surrogate  // Unicode Scalar Value₁₆, leading 0s allowed as long as length ≤ 6
 surrogate := [\u{D800}-\u{DFFF}]
 
 raw-string := '#' raw-string-quotes '#' | '#' raw-string '#'

--- a/tests/test_cases/input/unicode_escaped_above_max_fail.kdl
+++ b/tests/test_cases/input/unicode_escaped_above_max_fail.kdl
@@ -1,0 +1,1 @@
+no "Higher than max Unicode Scalar Value \u{10FFFF} \u{11FFFF}"

--- a/tests/test_cases/input/unicode_escaped_noncanon_fail.kdl
+++ b/tests/test_cases/input/unicode_escaped_noncanon_fail.kdl
@@ -1,1 +1,0 @@
-no "Non-canonical format for Unicode Scalar Value with extra 0s: \u{00FFFF} instead of \u{FFFF}"

--- a/tests/test_cases/input/unicode_escaped_noncanon_fail.kdl
+++ b/tests/test_cases/input/unicode_escaped_noncanon_fail.kdl
@@ -1,0 +1,1 @@
+no "Non-canonical format for Unicode Scalar Value with extra 0s: \u{00FFFF} instead of \u{FFFF}"

--- a/tests/test_cases/input/unicode_escaped_too_long_lead0_fail.kdl
+++ b/tests/test_cases/input/unicode_escaped_too_long_lead0_fail.kdl
@@ -1,0 +1,1 @@
+no "Even with leading 0s Unicode Scalar Value escapes must ≤6: \u{0123456}"

--- a/tests/test_cases/input/unicode_escaped_too_long_lead0_fail.kdl
+++ b/tests/test_cases/input/unicode_escaped_too_long_lead0_fail.kdl
@@ -1,1 +1,1 @@
-no "Even with leading 0s Unicode Scalar Value escapes must ≤6: \u{0123456}"
+no "Even with leading 0s Unicode Scalar Value escapes must ≤6: \u{0012345}"


### PR DESCRIPTION
Similar to https://github.com/kdl-org/kdl/pull/450 but explicitly modifies the escaped unicode grammar rule to exclude non Unicode Scalar Values which aren't surrogates, i.e., everything above `10FFFF`

(also simplifies surrogate regex to use ranges)

includes `000F` format as long as it's not exceeding 6 digits (though now the rule is in the comments)