### PR TITLE
Fix q-ws rule in KQL grammar

### DIFF
--- a/QUERY-SPEC.md
+++ b/QUERY-SPEC.md
@@ -127,5 +127,5 @@ comparison := accessor q-ws* matcher-operator q-ws* ($type | $string | $number |
 accessor := "val(" q-ws* $integer q-ws* ")" | "prop(" q-ws* $string q-ws* ")" | "name(" q-ws* ")" | "tag(" q-ws* ")" | "values(" q-ws* ")" | "props(" q-ws* ")" | $string
 matcher-operator := "=" | "!=" | ">" | "<" | ">=" | "<=" | "^=" | "$=" | "*="
 
-q-ws := $plain-node-space
+q-ws := $node-space
 ```


### PR DESCRIPTION
`plain-node-space` no longer exists in the KDL grammar, but was last defined as

    plain-node-space := ws* escline ws* | ws+

which matches the current definition of `node-space`.