### PR TITLE
Align spec prose on initial identifier characters with grammar

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -344,10 +344,17 @@ The following characters cannot be the first character in an
 * Any decimal digit (0-9)
 * Any [non-identifier characters](#non-identifier-characters)
 
-Additionally, the `-` character can only be used as an initial character if
-the second character is *not* a digit. This allows identifiers to look like
-`--this`, and removes the ambiguity of having an identifier look like a
-negative number.
+Additionally, the following initial characters impose limitations on subsequent
+characters:
+
+* the `+` and `-` characters can only be used as an initial character if
+  the second character is *not* a digit. If the second character is `.`, then
+  the third character must *not* be a digit.
+* the `.` character can only be used as an initial character if
+  the second character is *not* a digit.
+
+This allows identifiers to look like `--this` or `.md`, and removes the
+ambiguity of having an identifier look like a number.
 
 #### Non-identifier characters
 


### PR DESCRIPTION
I noticed that the spec prose didn't match the grammar which states

```
identifier-string := unambiguous-ident | signed-ident | dotted-ident
unambiguous-ident := ((identifier-char - digit - sign - '.') identifier-char*) - disallowed-keyword-strings
signed-ident := sign ((identifier-char - digit - '.') identifier-char*)?
dotted-ident := sign? '.' ((identifier-char - digit) identifier-char*)?
```