### PR TITLE
minor tweaks to wording/clarifications

### DIFF
--- a/tests/test_cases/expected_kdl/multiline_string_wrapped_binary.kdl
+++ b/tests/test_cases/expected_kdl/multiline_string_wrapped_binary.kdl
@@ -1,0 +1,1 @@
+node "deadbeef"

--- a/tests/test_cases/input/multiline_string_wrapped_binary.kdl
+++ b/tests/test_cases/input/multiline_string_wrapped_binary.kdl
@@ -1,0 +1,4 @@
+node """
+    dead\
+    beef
+    """


### PR DESCRIPTION
these are just a few minor wording tweaks and a test I thought might be useful, since it occurred to me that we can do stuff like spread a big base64 binary across several lines using `\`.

I also snuck in `Ascii85` because that seems handy to mention, but I'm happy to take it out if that's controversial.