### PR TITLE
Fix typo: RFC1123 is the RFC that defines requirements for hostnames

### DIFF
--- a/SCHEMA-SPEC.md
+++ b/SCHEMA-SPEC.md
@@ -287,7 +287,7 @@ and property names when the `node-names` or `prop-names` options are activated.
     * `country-subdivision`: ISO 3166-2 country subdivision code.
     * `email`: RFC5302 email address.
     * `idn-email`: RFC6531 internationalized email address.
-    * `hostname`: RFC1132 internet hostname.
+    * `hostname`: RFC1123 internet hostname.
     * `idn-hostname`: RFC5890 internationalized internet hostname.
     * `ipv4`: RFC2673 dotted-quad IPv4 address.
     * `ipv6`: RFC2373 IPv6 address.

--- a/SPEC_v1.md
+++ b/SPEC_v1.md
@@ -313,7 +313,7 @@ IEEE 754-2008 decimal floating point numbers
 * `country-subdivision`: ISO 3166-2 country subdivision code.
 * `email`: RFC5322 email address.
 * `idn-email`: RFC6531 internationalized email address.
-* `hostname`: RFC1132 internet hostname (only ASCII segments)
+* `hostname`: RFC1123 internet hostname (only ASCII segments)
 * `idn-hostname`: RFC5890 internationalized internet hostname (only `xn--`-prefixed ASCII "punycode" segments, or non-ASCII segments)
 * `ipv4`: RFC2673 dotted-quad IPv4 address.
 * `ipv6`: RFC2373 IPv6 address.

--- a/draft-marchan-kdl2.md
+++ b/draft-marchan-kdl2.md
@@ -315,7 +315,7 @@ IEEE 754-2008 decimal floating point numbers
 * `country-subdivision`: ISO 3166-2 country subdivision code.
 * `email`: RFC5322 email address.
 * `idn-email`: RFC6531 internationalized email address.
-* `hostname`: RFC1132 internet hostname (only ASCII segments)
+* `hostname`: RFC1123 internet hostname (only ASCII segments)
 * `idn-hostname`: RFC5890 internationalized internet hostname
   (only `xn--`-prefixed ASCII "punycode" segments, or non-ASCII segments)
 * `ipv4`: RFC2673 dotted-quad IPv4 address.


### PR DESCRIPTION
RFC1123 is [Requirements for Internet Hosts -- Application and Support](https://www.rfc-editor.org/rfc/rfc1123)
RFC1132 is [A Standard for the Transmission of 802.2 Packets over IPX Networks](https://www.rfc-editor.org/rfc/rfc1132)

This change applies to V1, V2, and the schema spec.