### PR TITLE
Make whitespace required around query operators

### DIFF
--- a/QUERY-SPEC.md
+++ b/QUERY-SPEC.md
@@ -115,15 +115,15 @@ what they expand to.
 
 ```
 query-str := $bom? query
-query := selector q-ws* "||" q-ws* query | selector
-selector := filter q-ws* selector-operator q-ws* selector-subsequent | filter
-selector-subsequent := matchers q-ws* selector-operator q-ws* selector-subsequent | matchers
+query := selector q-ws+ "||" q-ws+ query | selector
+selector := filter q-ws+ selector-operator q-ws+ selector-subsequent | filter
+selector-subsequent := matchers q-ws+ selector-operator q-ws+ selector-subsequent | matchers
 selector-operator := ">>" | ">" | "++" | "+"
 filter := "top(" q-ws* ")" | matchers
 matchers := type-matcher $string? accessor-matcher* | $string accessor-matcher* | accessor-matcher+
 type-matcher := "(" q-ws* ")" | $type
 accessor-matcher := "[" q-ws* (comparison | accessor)? q-ws* "]"
-comparison := accessor q-ws* matcher-operator q-ws* ($type | $string | $number | $keyword)
+comparison := accessor q-ws+ matcher-operator q-ws+ ($type | $string | $number | $keyword)
 accessor := "val(" q-ws* $integer q-ws* ")" | "prop(" q-ws* $string q-ws* ")" | "name(" q-ws* ")" | "tag(" q-ws* ")" | "values(" q-ws* ")" | "props(" q-ws* ")" | $string
 matcher-operator := "=" | "!=" | ">" | "<" | ">=" | "<=" | "^=" | "$=" | "*="
 


### PR DESCRIPTION
As mentioned in https://github.com/kdl-org/kdl/issues/489, we need this whitespace to remove ambiguity around `^$*<>+|` characters in identifiers vs in the query operators.