### PR TITLE
Align test formatting

### DIFF
--- a/tests/test_cases/expected_kdl/multiline_string_wrapped_binary.kdl
+++ b/tests/test_cases/expected_kdl/multiline_string_wrapped_binary.kdl
@@ -1,1 +1,1 @@
-node "deadbeef"
+node deadbeef


### PR DESCRIPTION
Other tests don't have quotes around strings if the string is a valid identifier, this test is the odd one out.