### PR TITLE
Align KDL Query grammar with prose

### DIFF
--- a/QUERY-SPEC.md
+++ b/QUERY-SPEC.md
@@ -124,7 +124,7 @@ matchers := type-matcher $string? accessor-matcher* | $string accessor-matcher* 
 type-matcher := "(" q-ws* ")" | $type
 accessor-matcher := "[" q-ws* (comparison | accessor)? q-ws* "]"
 comparison := accessor q-ws+ matcher-operator q-ws+ ($type | $string | $number | $keyword)
-accessor := "val(" q-ws* $integer q-ws* ")" | "prop(" q-ws* $string q-ws* ")" | "name(" q-ws* ")" | "tag(" q-ws* ")" | "values(" q-ws* ")" | "props(" q-ws* ")" | $string
+accessor := "val(" q-ws* $integer? q-ws* ")" | "prop(" q-ws* $string q-ws* ")" | "name(" q-ws* ")" | "tag(" q-ws* ")" | $string
 matcher-operator := "=" | "!=" | ">" | "<" | ">=" | "<=" | "^=" | "$=" | "*="
 
 q-ws := $node-space


### PR DESCRIPTION
The values() and props() accessors were only mentioned in the grammaer, with no explanation whatsoever about what they were supposed to do.

The val() accessor required an argument in the grammar while the prose repeatedly mentions val() as equivalent to val(0).

This was mentioned in #489. The other changes proposed in that issue are a bit more impactful (rename `val()` to `arg()`, introduce negation syntax, introduce equivalent to CSS `:is()`) so I wanted to get this one out of the way first.