### PR TITLE
Actually state in the normative portion how whitespace-only lines are treated. Related to #515

### DIFF
--- a/draft-marchan-kdl2.md
+++ b/draft-marchan-kdl2.md
@@ -523,7 +523,7 @@ is, empty multi-line strings are legal).
 In other words, the final line specifies the whitespace prefix that will be
 removed from all other lines.
 
-Whitespace-only lines (that is, lines containing only literal whitespace 
+Whitespace-only lines (that is, lines containing only literal whitespace
 characters, not including whitespace escapes like `\t`) always represent
 empty lines in the string value, regardless of what whitespace they
 contain (if any). They do not have to start with the same whitespace prefix

--- a/draft-marchan-kdl2.md
+++ b/draft-marchan-kdl2.md
@@ -523,6 +523,12 @@ is, empty multi-line strings are legal).
 In other words, the final line specifies the whitespace prefix that will be
 removed from all other lines.
 
+Whitespace-only lines (that is, lines containing only literal whitespace 
+characters, not including whitespace escapes like `\t`) always represent
+empty lines in the string value, regardless of what whitespace they
+contain (if any). They do not have to start with the same whitespace prefix
+that other lines do; all characters on the line are ignored.
+
 Multi-line Strings that do not immediately start with a Newline and whose final
 `"""` is not preceeded by optional whitespace and a Newline are illegal. This
 also means that `"""` may not be used for a single-line String (e.g.


### PR DESCRIPTION
This has been brought up a few times, let's finally fix it. ^_^ While technically a normative change (since it's adding normative text that was previously only implied by an informative example), this brings the spec in line with the testsuite, and is the intended behavior.