### PR TITLE
fix typo in spec grammar (disallowed-keyword-strings)

### DIFF
--- a/draft-marchan-kdl2.md
+++ b/draft-marchan-kdl2.md
@@ -973,7 +973,7 @@ string := identifier-string | quoted-string | raw-string ¶
 identifier-string := unambiguous-ident | signed-ident | dotted-ident
 unambiguous-ident :=
     ((identifier-char - digit - sign - '.') identifier-char*)
-    - disallowed-keyword-strings
+    - disallowed-keyword-identifiers
 signed-ident :=
     sign ((identifier-char - digit - '.') identifier-char*)?
 dotted-ident :=


### PR DESCRIPTION
disallowed-keyword-identifiers was referred to as disallowed-keyword-strings