### PR TITLE
QUERY-SPEC.md: the argument to val() is optional

### DIFF
--- a/QUERY-SPEC.md
+++ b/QUERY-SPEC.md
@@ -124,7 +124,7 @@ matchers := type-matcher $string? accessor-matcher* | $string accessor-matcher* 
 type-matcher := "(" q-ws* ")" | $type
 accessor-matcher := "[" q-ws* (comparison | accessor)? q-ws* "]"
 comparison := accessor q-ws+ matcher-operator q-ws+ ($type | $string | $number | $keyword)
-accessor := "val(" q-ws* $integer q-ws* ")" | "prop(" q-ws* $string q-ws* ")" | "name(" q-ws* ")" | "tag(" q-ws* ")" | "values(" q-ws* ")" | "props(" q-ws* ")" | $string
+accessor := "val(" q-ws* $integer? q-ws* ")" | "prop(" q-ws* $string q-ws* ")" | "name(" q-ws* ")" | "tag(" q-ws* ")" | "values(" q-ws* ")" | "props(" q-ws* ")" | $string
 matcher-operator := "=" | "!=" | ">" | "<" | ">=" | "<=" | "^=" | "$=" | "*="
 
 q-ws := $node-space


### PR DESCRIPTION
small difference between the prose description and the grammar.