### PR TITLE
KQL: swap around order of comparisons to reduce local ambiguity

### DIFF
--- a/QUERY-SPEC.md
+++ b/QUERY-SPEC.md
@@ -125,7 +125,7 @@ type-matcher := "(" q-ws* ")" | $type
 accessor-matcher := "[" q-ws* (comparison | accessor)? q-ws* "]"
 comparison := accessor q-ws+ matcher-operator q-ws+ ($type | $string | $number | $keyword)
 accessor := "val(" q-ws* $integer q-ws* ")" | "prop(" q-ws* $string q-ws* ")" | "name(" q-ws* ")" | "tag(" q-ws* ")" | "values(" q-ws* ")" | "props(" q-ws* ")" | $string
-matcher-operator := "=" | "!=" | ">" | "<" | ">=" | "<=" | "^=" | "$=" | "*="
+matcher-operator := "=" | "!=" | ">=" | "<=" | ">" | "<" | "^=" | "$=" | "*="
 
 q-ws := $node-space
 ```


### PR DESCRIPTION
generally in {A,E}BNF, if one literal is a prefix of another, the longer one is specified first, otherwise the shorter one will always match, either causing a spurious error or a parsing ambiguity, unless using a parser architecture which automatically resolved local ambiguities by collecting alternatives.

this is something the rest of the KDL and KQL specs do well, but it seems this case slipped through the cracks.