### PR TITLE
KQL: fix link to KDL grammar

### DIFF
--- a/QUERY-SPEC.md
+++ b/QUERY-SPEC.md
@@ -110,7 +110,7 @@ Then the following queries are valid:
 ## Full Grammar
 
 Rules that are not defined in this grammar are prefixed with `$`, see [the KDL
-grammar](https://kdl-org.github.io/kdl/#go.draft-marchan-kdl2.html#full-grammar) for
+grammar](https://kdl.dev/spec/#name-full-grammar) for
 what they expand to.
 
 ```


### PR DESCRIPTION
old link is 404