### PR TITLE
docs: add link to Zed extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ entirety, but in the future, may be required to in order to be included here.
 * [VS Code](https://marketplace.visualstudio.com/items?itemName=kdl-org.kdl&ssr=false#review-details)\*
 * [vim](https://github.com/imsnif/kdl.vim)
 * [Kate](https://github.com/larsgw/katepart-kdl)\*
+* [Zed](https://zed.dev/extensions/kdl)
 
 \* Supports KDL 2.0.0
 


### PR DESCRIPTION
I saw that the Zed extension wasn't mentioned on the website/readme :)