### PR TITLE
Added KdlSharp to readme README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ of some examples of KDL in the wild (either v1, v2, or both):
 |---|---|---|---|---|
 | C | [ckdl](https://github.com/tjol/ckdl) | ✅ | ✅ | |
 | C#/.NET | [Kadlet](https://github.com/oledfish/Kadlet) | ✅ | ✖️ | |
+| C#/.NET | [KadSharp](https://github.com/AndreyAkinshin/KdlSharp) | ✅ | ✅ | .NET Std: 2.1+, .NET 6+, .NET FW 4.7.2+, Mono, Xamarin |
 | C++ | [kdlpp](https://github.com/tjol/ckdl) | ✅ | ✅ | part of ckdl, requires C++20 |
 | Common Lisp | [kdlcl](https://github.com/chee/kdlcl) | ✅ | ✖️ | |
 | Crystal | [kdl-cr](https://github.com/danini-the-panini/kdl-cr) | ✅ | ✖️ | |


### PR DESCRIPTION
since Kadlet is not maintained, I proposed adding KdlSharp for v2 users in a [discussion](https://github.com/kdl-org/kdl/discussions/550)

I also added the requirements in the note (from KdlSharp README.MD). I abbreviated them to fit in the width of the table.

I hope the style is fine