### PR TITLE
use a valid keyword in just_space_in_arg_type_fail

### DIFF
--- a/tests/test_cases/input/just_space_in_arg_type_fail.kdl
+++ b/tests/test_cases/input/just_space_in_arg_type_fail.kdl
@@ -1,1 +1,1 @@
-node ( )false
+node ( )#false


### PR DESCRIPTION
while this test should fail early on the type annotation, i think it's still better to keep a single point of failure