### PR TITLE
add kdly to Go implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ of some examples of KDL in the wild (either v1, v2, or both):
 | Go | [gokdl](https://github.com/lunjon/gokdl) | ✅ | ✖️ | |
 | Go | [kdl-go](https://github.com/sblinch/kdl-go) | ✅ | ✖️ | |
 | Go | [gokdl2](https://github.com/njreid/gokdl2) | ✅ | ✅ | Friendly errors & arena allocator |
+| Go | [kdly](https://codeberg.org/shimeoki/kdly) | ✖️ | ✅ | Format/comment-preserving parser |
 | Haskell | [Hustle](https://github.com/fuzzypixelz/Hustle) | ✅ | ✖️ | |
 | Haskell | [kdl-hs](https://github.com/brandonchinn178/kdl-hs) | ✅ | ✅ | Format/comment-preserving parser |
 | Java | [kdl4j](https://github.com/kdl-org/kdl4j) | ✅ | ✅ | |


### PR DESCRIPTION
while it's still in alpha, i want to share this project and include it in the implementations list. also, as a "proof of concept" that it works, i built [a formatter](https://codeberg.org/shimeoki/kdlf) on top of it.

and i wanted to ask a question about tooling. for example, there are [kdlfmt](https://github.com/hougesen/kdlfmt), [kdl-fmt](https://github.com/dj95/kdl-fmt), [kdl-lsp](https://github.com/kdl-org/kdl-rs/tree/main/tools/kdl-lsp) from [kdl-rs](https://github.com/kdl-org/kdl-rs) and my aforementioned formatter. should there also be a separate section for tools? while implementations are more important, i think keeping track of projects to interact with the language is still worth mentioning.